### PR TITLE
Additional check

### DIFF
--- a/SizePlayer/src/SizePLayer/SizePLayerCommand.php
+++ b/SizePlayer/src/SizePLayer/SizePLayerCommand.php
@@ -23,6 +23,9 @@ class SizePLayerCommand extends Command{
                     if($args[0] > 20){
                       $player->sendMessage("Size cannot be bigger then 20");
                       return true;
+                    }elseif($args[0] <= 0){
+                      $player->sendMessage("Size cannot be smaller than or eqaul to 0");
+                      return true;
                     }
                     $this->plugin->size[$player->getName()] = $args[0];
                     $player->setScale($args[0]);


### PR DESCRIPTION
Size should not be less than or equal zero due to:
- 1- If a player attempted to change his/her size after setting it to 0 , A division by zero (which is not possible) error will be thrown. (This is error is caused by the core btw)

- 2- Size zero means invisible. I know that the nametag is still seen. Yet, players shouldn't IMO be invisible because of a size change.

- 3- Sizes with negative numbers could cause some glitches and activate the anti-cheat system